### PR TITLE
Update Doctrine Coding Standard to ^10.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,18 +23,18 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "doctrine/coding-standard": "^9.0",
-        "ergebnis/composer-normalize": "^2.15",
-        "infection/infection": "^0",
-        "laminas/laminas-diactoros": "^2.8",
+        "doctrine/coding-standard": "^10.0.0",
+        "ergebnis/composer-normalize": "^2.28.3",
+        "infection/infection": "^0.26.6",
+        "laminas/laminas-diactoros": "^2.16.0",
         "php-http/curl-client": "^2.2",
-        "phpunit/phpunit": "^9.5.10",
-        "psalm/plugin-phpunit": "^0.16.1 || ^0.17.0",
-        "react/child-process": "^0.6.3",
-        "react/http": "^1.5",
+        "phpunit/phpunit": "^9.5.23",
+        "psalm/plugin-phpunit": "^0.17.0",
+        "react/child-process": "^0.6.4",
+        "react/http": "^1.7.0",
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "^3.6",
-        "vimeo/psalm": "^4.10"
+        "squizlabs/php_codesniffer": "^3.7.1",
+        "vimeo/psalm": "^4.26.0"
     },
     "config": {
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8fbd8925c9aa6b01145aeaed9af50ec",
+    "content-hash": "7c7b34c82c79cea501270ddacc69bc2d",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1544,23 +1544,23 @@
         },
         {
             "name": "doctrine/coding-standard",
-            "version": "9.0.2",
+            "version": "10.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/coding-standard.git",
-                "reference": "35a2452c6025cb739c3244b3348bcd1604df07d1"
+                "reference": "7903671d7d33c231c8921058b7c14b8f57cbacb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/35a2452c6025cb739c3244b3348bcd1604df07d1",
-                "reference": "35a2452c6025cb739c3244b3348bcd1604df07d1",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/7903671d7d33c231c8921058b7c14b8f57cbacb7",
+                "reference": "7903671d7d33c231c8921058b7c14b8f57cbacb7",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "php": "^7.1 || ^8.0",
-                "slevomat/coding-standard": "^7.0.0",
-                "squizlabs/php_codesniffer": "^3.6.0"
+                "php": "^7.2 || ^8.0",
+                "slevomat/coding-standard": "^8.2",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -1593,9 +1593,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/coding-standard/issues",
-                "source": "https://github.com/doctrine/coding-standard/tree/9.0.2"
+                "source": "https://github.com/doctrine/coding-standard/tree/10.0.0"
             },
-            "time": "2021-04-12T15:11:14+00:00"
+            "time": "2022-08-26T10:53:05+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -6407,37 +6407,37 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "7.2.1",
+            "version": "8.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90"
+                "reference": "02f27326be19633a1b6ba76745390bbf9a4be0b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/aff06ae7a84e4534bf6f821dc982a93a5d477c90",
-                "reference": "aff06ae7a84e4534bf6f821dc982a93a5d477c90",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/02f27326be19633a1b6ba76745390bbf9a4be0b6",
+                "reference": "02f27326be19633a1b6ba76745390bbf9a4be0b6",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.5.1",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "phpstan/phpdoc-parser": ">=1.7.0 <1.8.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
             "require-dev": {
-                "phing/phing": "2.17.3",
+                "phing/phing": "2.17.4",
                 "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.4.10|1.7.1",
+                "phpstan/phpstan": "1.4.10|1.8.2",
                 "phpstan/phpstan-deprecation-rules": "1.0.0",
                 "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
-                "phpstan/phpstan-strict-rules": "1.2.3",
-                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
+                "phpstan/phpstan-strict-rules": "1.3.0",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.21"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.x-dev"
+                    "dev-master": "8.x-dev"
                 }
             },
             "autoload": {
@@ -6452,7 +6452,7 @@
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/7.2.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.4.0"
             },
             "funding": [
                 {
@@ -6464,7 +6464,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-25T10:58:12+00:00"
+            "time": "2022-08-09T19:03:45+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/src/BaseClient.php
+++ b/src/BaseClient.php
@@ -62,7 +62,7 @@ final class BaseClient implements Client
             $this->requestFactory,
             $this->uriFactory,
             $this->streamFactory,
-            $this->baseUri
+            $this->baseUri,
         );
     }
 
@@ -84,7 +84,7 @@ final class BaseClient implements Client
     public function fetchAllDefinitions(): iterable
     {
         $response = $this->send(
-            $this->request('GET', '/customtypes')
+            $this->request('GET', '/customtypes'),
         );
 
         $body = Json::decodeToArray((string) $response->getBody());
@@ -117,7 +117,7 @@ final class BaseClient implements Client
         $request = $this->request('POST', '/customtypes/insert')
             ->withHeader('Content-Type', 'application/json')
             ->withBody($this->streamFactory->createStream(
-                Json::encodeObject($definition)
+                Json::encodeObject($definition),
             ));
 
         $response = $this->send($request);
@@ -140,7 +140,7 @@ final class BaseClient implements Client
         $request = $this->request('POST', '/customtypes/update')
             ->withHeader('Content-Type', 'application/json')
             ->withBody($this->streamFactory->createStream(
-                Json::encodeObject($definition)
+                Json::encodeObject($definition),
             ));
 
         $response = $this->send($request);
@@ -180,7 +180,7 @@ final class BaseClient implements Client
         $request = $this->requestFactory->createRequest(
             $method,
             $this->uriFactory->createUri($this->baseUri)
-                ->withPath($path)
+                ->withPath($path),
         );
 
         return $request->withHeader('repository', $this->repository)

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -7,9 +7,7 @@ namespace Prismic\DocumentType;
 use JsonSerializable;
 use Prismic\DocumentType\Exception\AssertionFailed;
 
-/**
- * @psalm-immutable
- */
+/** @psalm-immutable */
 final class Definition implements JsonSerializable
 {
     private string $id;
@@ -63,7 +61,7 @@ final class Definition implements JsonSerializable
             $data['label'],
             $data['repeatable'],
             $data['status'],
-            Json::encodeArray($data['json'])
+            Json::encodeArray($data['json']),
         );
     }
 

--- a/src/Exception/AuthenticationFailed.php
+++ b/src/Exception/AuthenticationFailed.php
@@ -14,7 +14,7 @@ final class AuthenticationFailed extends ResponseError
         return self::withHttpExchange(
             'Authentication failed. This could mean a missing or invalid token, or an incorrect repository',
             $request,
-            $response
+            $response,
         );
     }
 }

--- a/src/Exception/DefinitionNotFound.php
+++ b/src/Exception/DefinitionNotFound.php
@@ -19,7 +19,7 @@ final class DefinitionNotFound extends ResponseError
         return self::withHttpExchange(
             sprintf('A custom type with the id "%s" cannot be found', $id),
             $request,
-            $response
+            $response,
         );
     }
 }

--- a/src/Exception/InsertFailed.php
+++ b/src/Exception/InsertFailed.php
@@ -20,10 +20,10 @@ final class InsertFailed extends ResponseError
         return self::withHttpExchange(
             sprintf(
                 'Failed to insert the definition "%s" because one already exists with that identifier',
-                $definition->id()
+                $definition->id(),
             ),
             $request,
-            $response
+            $response,
         );
     }
 }

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -14,7 +14,7 @@ final class InvalidDefinition extends ResponseError
         return self::withHttpExchange(
             'The document type definition was rejected because it (most likely) has validation errors',
             $request,
-            $response
+            $response,
         );
     }
 }

--- a/src/Exception/JsonError.php
+++ b/src/Exception/JsonError.php
@@ -14,30 +14,26 @@ final class JsonError extends RuntimeException implements Exception
 {
     private ?string $jsonString = null;
 
-    /**
-     * @psalm-suppress InvalidScalarArgument
-     */
+    /** @psalm-suppress InvalidScalarArgument */
     public static function onDecode(string $payload, JsonException $error): self
     {
         $instance = new self(
             sprintf('JSON Decode Failure: %s', $error->getMessage()),
             $error->getCode(),
-            $error
+            $error,
         );
         $instance->jsonString = $payload;
 
         return $instance;
     }
 
-    /**
-     * @psalm-suppress InvalidScalarArgument
-     */
+    /** @psalm-suppress InvalidScalarArgument */
     public static function onEncode(JsonException $error): self
     {
         return new self(
             sprintf('JSON Encode Failure: %s', $error->getMessage()),
             $error->getCode(),
-            $error
+            $error,
         );
     }
 

--- a/src/Exception/RequestFailure.php
+++ b/src/Exception/RequestFailure.php
@@ -20,7 +20,7 @@ final class RequestFailure extends RuntimeException implements Exception
         $instance = new self(sprintf(
             'The request to "%s" failed: %s',
             $request->getUri()->getPath(),
-            $error->getMessage()
+            $error->getMessage(),
         ), 0, $error);
 
         $instance->request = $request;
@@ -33,7 +33,7 @@ final class RequestFailure extends RuntimeException implements Exception
         Assert::isInstanceOf(
             $this->request,
             RequestInterface::class,
-            'This error was not constructed with a request instance'
+            'This error was not constructed with a request instance',
         );
 
         return $this->request;

--- a/src/Exception/ResponseError.php
+++ b/src/Exception/ResponseError.php
@@ -21,9 +21,7 @@ abstract class ResponseError extends RuntimeException implements Exception
         parent::__construct($message, $code, $previous);
     }
 
-    /**
-     * @return static
-     */
+    /** @return static */
     final protected static function withHttpExchange(
         string $message,
         RequestInterface $request,
@@ -41,7 +39,7 @@ abstract class ResponseError extends RuntimeException implements Exception
         Assert::isInstanceOf(
             $this->request,
             RequestInterface::class,
-            'This error was not constructed with a request instance'
+            'This error was not constructed with a request instance',
         );
 
         return $this->request;
@@ -52,7 +50,7 @@ abstract class ResponseError extends RuntimeException implements Exception
         Assert::isInstanceOf(
             $this->response,
             ResponseInterface::class,
-            'This error was not constructed with a response instance'
+            'This error was not constructed with a response instance',
         );
 
         return $this->response;

--- a/src/Exception/UnexpectedStatusCode.php
+++ b/src/Exception/UnexpectedStatusCode.php
@@ -17,10 +17,10 @@ final class UnexpectedStatusCode extends ResponseError
             sprintf(
                 'Expected the HTTP response code %d but received %d',
                 $code,
-                $response->getStatusCode()
+                $response->getStatusCode(),
             ),
             $request,
-            $response
+            $response,
         );
     }
 }

--- a/src/Exception/UpdateFailed.php
+++ b/src/Exception/UpdateFailed.php
@@ -20,10 +20,10 @@ final class UpdateFailed extends ResponseError
         return self::withHttpExchange(
             sprintf(
                 'Failed to update the definition "%s" because it has not yet been created',
-                $definition->id()
+                $definition->id(),
             ),
             $request,
-            $response
+            $response,
         );
     }
 }

--- a/src/Json.php
+++ b/src/Json.php
@@ -34,9 +34,7 @@ final class Json
         }
     }
 
-    /**
-     * @param array<array-key, mixed> $parameters
-     */
+    /** @param array<array-key, mixed> $parameters */
     public static function encodeArray(array $parameters): string
     {
         try {

--- a/test/Integration/BaseClientTest.php
+++ b/test/Integration/BaseClientTest.php
@@ -38,7 +38,7 @@ class BaseClientTest extends MockServerTestCase
             $this->requestFactory(),
             new UriFactory(),
             new StreamFactory(),
-            self::apiServerUri()
+            self::apiServerUri(),
         );
     }
 
@@ -54,7 +54,7 @@ class BaseClientTest extends MockServerTestCase
         self::assertEquals(
             $error->response()->getStatusCode(),
             $error->getCode(),
-            'The error code does not match the response status code'
+            'The error code does not match the response status code',
         );
     }
 
@@ -67,7 +67,7 @@ class BaseClientTest extends MockServerTestCase
             $this->requestFactory(),
             new UriFactory(),
             new StreamFactory(),
-            'http://192.0.2.1'
+            'http://192.0.2.1',
         );
 
         $this->expectException(RequestFailure::class);
@@ -124,7 +124,7 @@ class BaseClientTest extends MockServerTestCase
             'Foo',
             true,
             true,
-            '{"foo":"bar"}'
+            '{"foo":"bar"}',
         ));
 
         $last = $this->httpClient()->lastRequest();
@@ -143,7 +143,7 @@ class BaseClientTest extends MockServerTestCase
                 'Foo',
                 true,
                 true,
-                '{"foo":"bar"}'
+                '{"foo":"bar"}',
             ));
         } catch (InvalidDefinition $error) {
             $this->assertExceptionContainsReferenceToTheLastErroneousRequest($error);
@@ -164,7 +164,7 @@ class BaseClientTest extends MockServerTestCase
                 'Foo',
                 true,
                 true,
-                '{"foo":"bar"}'
+                '{"foo":"bar"}',
             ));
         } catch (InsertFailed $error) {
             $this->assertExceptionContainsReferenceToTheLastErroneousRequest($error);
@@ -185,7 +185,7 @@ class BaseClientTest extends MockServerTestCase
                 'In Mock Server',
                 true,
                 true,
-                '{"causes":"a 500 error"}'
+                '{"causes":"a 500 error"}',
             ));
         } catch (UnexpectedStatusCode $error) {
             $this->assertExceptionContainsReferenceToTheLastErroneousRequest($error);
@@ -226,7 +226,7 @@ class BaseClientTest extends MockServerTestCase
             'Foo',
             true,
             true,
-            '{"foo":"bar"}'
+            '{"foo":"bar"}',
         ));
 
         $last = $this->httpClient()->lastRequest();
@@ -245,7 +245,7 @@ class BaseClientTest extends MockServerTestCase
                 'Foo',
                 true,
                 true,
-                '{"foo":"bar"}'
+                '{"foo":"bar"}',
             ));
         } catch (UpdateFailed $error) {
             $this->assertExceptionContainsReferenceToTheLastErroneousRequest($error);
@@ -266,7 +266,7 @@ class BaseClientTest extends MockServerTestCase
                 'Foo',
                 true,
                 true,
-                '{"foo":"bar"}'
+                '{"foo":"bar"}',
             ));
         } catch (InvalidDefinition $error) {
             $this->assertExceptionContainsReferenceToTheLastErroneousRequest($error);
@@ -287,7 +287,7 @@ class BaseClientTest extends MockServerTestCase
                 'In Mock Server',
                 true,
                 true,
-                '{"causes":"a 500 error"}'
+                '{"causes":"a 500 error"}',
             ));
         } catch (InvalidDefinition $error) {
             $this->assertExceptionContainsReferenceToTheLastErroneousRequest($error);
@@ -338,7 +338,7 @@ class BaseClientTest extends MockServerTestCase
             'Foo',
             true,
             true,
-            '{"foo":"bar"}'
+            '{"foo":"bar"}',
         ));
 
         $last = $this->httpClient()->lastRequest();
@@ -353,7 +353,7 @@ class BaseClientTest extends MockServerTestCase
             'Example',
             true,
             true,
-            '{"Main":{"value":{"type":"Number","config":{"label":"Value","min":0,"max":10}}}}'
+            '{"Main":{"value":{"type":"Number","config":{"label":"Value","min":0,"max":10}}}}',
         ));
 
         $last = $this->httpClient()->lastRequest();
@@ -372,7 +372,7 @@ class BaseClientTest extends MockServerTestCase
             'Example',
             true,
             true,
-            '{"foo":"bar"}'
+            '{"foo":"bar"}',
         ));
 
         $last = $this->httpClient()->lastRequest();

--- a/test/Integration/MockServer.php
+++ b/test/Integration/MockServer.php
@@ -31,9 +31,9 @@ final class MockServer
 
     public function __construct(int $port)
     {
-        $this->server = new HttpServer(function (RequestInterface $request): ResponseInterface {
-            return $this->handleRequest($request);
-        });
+        $this->server = new HttpServer(
+            fn (RequestInterface $request): ResponseInterface => $this->handleRequest($request),
+        );
         $this->socket = new SocketServer(sprintf('0.0.0.0:%d', $port));
     }
 
@@ -93,27 +93,21 @@ final class MockServer
                 'token' => self::VALID_TOKEN,
                 'path' => '/customtypes/insert',
                 'file' => __DIR__ . '/responses/POST.customtypes-insert.http',
-                'body' => static function (string $body): bool {
-                    return strpos($body, '"id":"not-found"') !== false;
-                },
+                'body' => static fn (string $body): bool => strpos($body, '"id":"not-found"') !== false,
             ],
             [
                 'method' => 'POST',
                 'token' => self::VALID_TOKEN,
                 'path' => '/customtypes/insert',
                 'file' => __DIR__ . '/responses/POST.customtypes-insert.invalid-spec.http',
-                'body' => static function (string $body): bool {
-                    return strpos($body, '"id":"invalid-insert"') !== false;
-                },
+                'body' => static fn (string $body): bool => strpos($body, '"id":"invalid-insert"') !== false,
             ],
             [
                 'method' => 'POST',
                 'token' => self::VALID_TOKEN,
                 'path' => '/customtypes/insert',
                 'file' => __DIR__ . '/responses/POST.customtypes-insert.duplicate.http',
-                'body' => static function (string $body): bool {
-                    return strpos($body, '"id":"duplicate-insert"') !== false;
-                },
+                'body' => static fn (string $body): bool => strpos($body, '"id":"duplicate-insert"') !== false,
             ],
             [
                 'method' => 'DELETE',
@@ -126,27 +120,21 @@ final class MockServer
                 'token' => self::VALID_TOKEN,
                 'path' => '/customtypes/update',
                 'file' => __DIR__ . '/responses/POST.customtypes-update.http',
-                'body' => static function (string $body): bool {
-                    return strpos($body, '"id":"example"') !== false;
-                },
+                'body' => static fn (string $body): bool => strpos($body, '"id":"example"') !== false,
             ],
             [
                 'method' => 'POST',
                 'token' => self::VALID_TOKEN,
                 'path' => '/customtypes/update',
                 'file' => __DIR__ . '/responses/POST.customtypes-update.not-found.http',
-                'body' => static function (string $body): bool {
-                    return strpos($body, '"id":"not-found-for-update"') !== false;
-                },
+                'body' => static fn (string $body): bool => strpos($body, '"id":"not-found-for-update"') !== false,
             ],
             [
                 'method' => 'POST',
                 'token' => self::VALID_TOKEN,
                 'path' => '/customtypes/update',
                 'file' => __DIR__ . '/responses/POST.customtypes-update.invalid-spec.http',
-                'body' => static function (string $body): bool {
-                    return strpos($body, '"id":"invalid-spec"') !== false;
-                },
+                'body' => static fn (string $body): bool => strpos($body, '"id":"invalid-spec"') !== false,
             ],
             [
                 'method' => 'GET',

--- a/test/Integration/MockServerTestCase.php
+++ b/test/Integration/MockServerTestCase.php
@@ -31,13 +31,13 @@ abstract class MockServerTestCase extends TestCase
     public static function setUpBeforeClass(): void
     {
         self::$httpClient = new HttpClient(
-            new Client(null, null, [CURLOPT_CONNECTTIMEOUT_MS => 100])
+            new Client(null, null, [CURLOPT_CONNECTTIMEOUT_MS => 100]),
         );
         self::$requestFactory = new RequestFactory();
         self::$serverPort = 8089;
         self::$serverProcess = new Process(
             sprintf('exec php %s/run-server.php %d', __DIR__, self::$serverPort),
-            __DIR__
+            __DIR__,
         );
         self::$serverProcess->start();
         usleep(100000);

--- a/test/Smoke/BaseClientTest.php
+++ b/test/Smoke/BaseClientTest.php
@@ -51,7 +51,7 @@ final class BaseClientTest extends TestCase
             Psr18ClientDiscovery::find(),
             Psr17FactoryDiscovery::findRequestFactory(),
             Psr17FactoryDiscovery::findUriFactory(),
-            Psr17FactoryDiscovery::findStreamFactory()
+            Psr17FactoryDiscovery::findStreamFactory(),
         );
     }
 
@@ -91,7 +91,7 @@ final class BaseClientTest extends TestCase
             'Example Definition',
             true,
             true,
-            '{"Main":{"value": {"type":"Number","config":{"label":"Value","min":0,"max":10}}}}'
+            '{"Main":{"value": {"type":"Number","config":{"label":"Value","min":0,"max":10}}}}',
         );
     }
 
@@ -175,7 +175,7 @@ final class BaseClientTest extends TestCase
             'Invalid Definition',
             true,
             true,
-            '{"Main":{"actually": "valid json, but invalid spec for Prismic"}}'
+            '{"Main":{"actually": "valid json, but invalid spec for Prismic"}}',
         );
 
         $this->expectException(InvalidDefinition::class);

--- a/test/Unit/DefinitionTest.php
+++ b/test/Unit/DefinitionTest.php
@@ -25,7 +25,7 @@ final class DefinitionTest extends TestCase
             'Custom Type',
             true,
             true,
-            '{"Foo":{}}'
+            '{"Foo":{}}',
         );
     }
 

--- a/test/Unit/Exception/RequestFailureTest.php
+++ b/test/Unit/Exception/RequestFailureTest.php
@@ -24,7 +24,7 @@ class RequestFailureTest extends TestCase
     {
         $error = RequestFailure::withPsrError(
             new Request('/foo'),
-            $this->createMock(ClientExceptionInterface::class)
+            $this->createMock(ClientExceptionInterface::class),
         );
 
         self::assertEquals(0, $error->getCode());
@@ -35,7 +35,7 @@ class RequestFailureTest extends TestCase
         $exception = $this->createMock(ClientExceptionInterface::class);
         $error = RequestFailure::withPsrError(
             new Request('/foo'),
-            $exception
+            $exception,
         );
 
         self::assertSame($exception, $error->getPrevious());

--- a/test/Unit/Exception/UnexpectedStatusCodeTest.php
+++ b/test/Unit/Exception/UnexpectedStatusCodeTest.php
@@ -16,12 +16,12 @@ class UnexpectedStatusCodeTest extends TestCase
         $error = UnexpectedStatusCode::withExpectedCode(
             123,
             $this->createMock(ServerRequestInterface::class),
-            new TextResponse('Foo', 234)
+            new TextResponse('Foo', 234),
         );
 
         self::assertEquals(
             'Expected the HTTP response code 123 but received 234',
-            $error->getMessage()
+            $error->getMessage(),
         );
     }
 }


### PR DESCRIPTION
Also bumps other dev dependencies

- Trailing commas in function calls
- Single line doc comments
- Use arrow functions where possible